### PR TITLE
Update project board link

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ You should receive a json response matching something like the following:
 
 ## Contributors
 The _Puff_ project is looking for contributors to join the initiative!
-For information about progress, features under construction and opportunities to contribute see [our project board](https://github.com/benjaminkostiuk/unity-test/projects/1).
+For information about progress, features under construction and opportunities to contribute see [our project board](https://github.com/orgs/puffproject/projects/1).
 
 
 If you're interested in helping please read our [CONTRIBUTING.md](./CONTRIBUTING.md) for details like our Code of Conduct and contact [Benjamin Kostiuk](mailto:benkostiuk1@gmail.com) for more information.


### PR DESCRIPTION
## Overview
Updated project board link

This change is a
- [X] Bug fix

## Description
Updated the contributing link in the test-runner readme.md to point to the project board

## Motivation/Links
closes https://github.com/puffproject/test-runner/issues/12

## How was this tested?
N/A

## Todos
- [X] Ensure unit tests pass
- [X] Update documentation for changes (if necessary)