### PR TITLE
assignmentId param for cases

### DIFF
--- a/src/main/java/com/unityTest/testrunner/restApi/CaseApi.java
+++ b/src/main/java/com/unityTest/testrunner/restApi/CaseApi.java
@@ -54,6 +54,7 @@ public interface CaseApi extends BaseApi {
 			Pageable pageable,
 			@ApiParam("Case id") @RequestParam(value = "id", required = false) Integer id,
 			@ApiParam("Suite id") @RequestParam(value = "suiteId", required = false) Integer suiteId,
+			@ApiParam("Assignment id") @RequestParam(value = "assignmentId", required = false) Integer assignmentId,
 			@ApiParam("Function name") @RequestParam(value = "name", required = false) String functionName,
 			@ApiParam("Programming language") @RequestParam(value = "lang", required = false) String lang);
 

--- a/src/main/java/com/unityTest/testrunner/restApi/UserApi.java
+++ b/src/main/java/com/unityTest/testrunner/restApi/UserApi.java
@@ -56,6 +56,7 @@ public interface UserApi extends BaseApi {
 			Pageable pageable,
 			@ApiParam("Test case id") @RequestParam(value = "id", required = false) Integer id,
 			@ApiParam("Suite id") @RequestParam(value = "suiteId", required = false) Integer suiteId,
+			@ApiParam("Assignment id") @RequestParam(value = "assignmentId", required = false) Integer assignmentId,
 			@ApiParam("Function name") @RequestParam(value = "name", required = false) String functionName,
 			@ApiParam("Programming language") @RequestParam(value = "lang", required = false) String lang);
 

--- a/src/main/java/com/unityTest/testrunner/restImpl/CaseController.java
+++ b/src/main/java/com/unityTest/testrunner/restImpl/CaseController.java
@@ -52,12 +52,13 @@ public class CaseController implements CaseApi {
 			Pageable pageable,
 			Integer id,
 			Integer suiteId,
+			Integer assignmentId,
 			String functionName,
 			String lang) {
 		// Convert lang to PLanguage
 		PLanguage pLanguage = Utils.parsePLanguage(lang);
 		// Retrieve results using service
-		Page<Case> casePage = caseService.getCases(pageable, id, suiteId, functionName, pLanguage, null);
+		Page<Case> casePage = caseService.getCases(pageable, id, suiteId, assignmentId, functionName, pLanguage, null);
 		TestCasePage page = new TestCasePage(casePage, keycloakService.getConnection(), keycloakService.getRealmName());
 		return new ResponseEntity<>(page, HttpStatus.OK);
 	}

--- a/src/main/java/com/unityTest/testrunner/restImpl/SuiteController.java
+++ b/src/main/java/com/unityTest/testrunner/restImpl/SuiteController.java
@@ -143,7 +143,7 @@ public class SuiteController implements SuiteApi {
 		if (ids == null || ids.size() == 0) {
 			int maxCaseCount = limit == null ? DEFAULT_LIMIT : limit;
 			Pageable pageable = PageRequest.of(0, maxCaseCount, Sort.Direction.DESC, Case_.UPVOTES);
-			cases = caseService.getCases(pageable, null, suiteId, null, null, null).getContent();
+			cases = caseService.getCases(pageable, null, suiteId, null, null, null, null).getContent();
 		} else {
 			cases = caseService.getCases(ids, suiteId);
 		}

--- a/src/main/java/com/unityTest/testrunner/restImpl/UserController.java
+++ b/src/main/java/com/unityTest/testrunner/restImpl/UserController.java
@@ -64,6 +64,7 @@ public class UserController implements UserApi {
 			Pageable pageable,
 			Integer id,
 			Integer suiteId,
+			Integer assignmentId,
 			String functionName,
 			String lang) {
 		AccessToken token = Utils.getAuthToken(principal); // Extract request access token
@@ -72,7 +73,8 @@ public class UserController implements UserApi {
 		// Convert lang to PLanguage
 		PLanguage pLanguage = Utils.parsePLanguage(lang);
 		// Call case service and build TestCasePage to return
-		Page<Case> page = caseService.getCases(pageable, id, suiteId, functionName, pLanguage, token.getSubject());
+		Page<Case> page =
+			caseService.getCases(pageable, id, suiteId, assignmentId, functionName, pLanguage, token.getSubject());
 		return new ResponseEntity<>(new TestCasePage(page, author), HttpStatus.OK);
 	}
 

--- a/src/main/java/com/unityTest/testrunner/service/CaseService.java
+++ b/src/main/java/com/unityTest/testrunner/service/CaseService.java
@@ -72,13 +72,20 @@ public class CaseService {
 	 * 
 	 * @param id Id of case to fetch
 	 * @param suiteId Suite id to match
+	 * @param assignmentId Id of associated assignment
 	 * @param functionName Function name of case to match
 	 * @param pLanguage Programming language of case to match
 	 * @param authorId Author id of case to match
 	 * @return List of cases with fields matching the passed arguments
 	 */
-	public List<Case> getCases(Integer id, Integer suiteId, String functionName, PLanguage pLanguage, String authorId) {
-		return getCases(Pageable.unpaged(), id, suiteId, functionName, pLanguage, authorId).getContent();
+	public List<Case> getCases(
+			Integer id,
+			Integer suiteId,
+			Integer assignmentId,
+			String functionName,
+			PLanguage pLanguage,
+			String authorId) {
+		return getCases(Pageable.unpaged(), id, suiteId, assignmentId, functionName, pLanguage, authorId).getContent();
 	}
 
 	/**
@@ -87,6 +94,7 @@ public class CaseService {
 	 * @param pageable Pageable object specifying page size, sort and index
 	 * @param id Id of case to fetch
 	 * @param suiteId Suite id to match
+	 * @param assignmentId Id of associated assignment
 	 * @param functionName Function name of case to match
 	 * @param pLanguage Programming language of case to match
 	 * @param authorId Author id of case to match
@@ -97,6 +105,7 @@ public class CaseService {
 			Pageable pageable,
 			Integer id,
 			Integer suiteId,
+			Integer assignmentId,
 			String functionName,
 			PLanguage pLanguage,
 			String authorId) {
@@ -104,6 +113,7 @@ public class CaseService {
 		Specification<Case> spec = new AndSpecification<Case>()
 			.equal(id, Case_.ID)
 			.equal(suiteId, Case_.SUITE, Suite_.ID)
+			.equal(assignmentId, Case_.SUITE, Suite_.ASSIGNMENT_ID)
 			.equal(functionName, Case_.FUNCTION_NAME)
 			.equal(pLanguage, Case_.LANGUAGE)
 			.equal(authorId, Case_.AUTHOR_ID)


### PR DESCRIPTION

## Overview
implemented the ability to filter by assignmentId when using the `GET /case` and `GET /user/cases` endpoints

This change is a
- [x] New feature (non-breaking change which adds functionality)


## Description
- Added a new query param (@RequestParam) for assignment id to the getUserTestCases and getTestCases functions.
- Updated the controllers that implement the interfaces and passed the new paramter to the case service.
- Update getCases functions to accept the new assignmentId parameter and built the correct specification.


## Motivation/Links
closes https://github.com/puffproject/test-runner/issues/4

## How was this tested?
- the new query parameter shows up when looking at the swagger UI
- the endpoint was tested by hand, and correctly filters by assignment id 

## Todos
N/A